### PR TITLE
validator: removes 10s delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "./lib/src/Index.js",
   "typings": "./lib/src/Index.d.ts",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "engines": {
     "node": "> 6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "./lib/src/Index.js",
   "typings": "./lib/src/Index.d.ts",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "engines": {
     "node": "> 6.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": false,
   "main": "./lib/src/Index.js",
   "typings": "./lib/src/Index.d.ts",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "engines": {
     "node": "> 6.0.0"
   },

--- a/src/SilentEchoValidator.ts
+++ b/src/SilentEchoValidator.ts
@@ -16,9 +16,6 @@ export class SilentEchoValidator {
             currentSequenceIndex += 1;
             if (currentSequenceIndex === 1) {
                 await this.silentEcho.message("Alexa, exit");
-                if (process.env.ENABLE_MESSAGES_MOCK !== "true") {
-                    await new Promise((resolve) => setTimeout(resolve, 10000));
-                }
             }
             for (const test of sequence.tests) {
                 try {
@@ -40,9 +37,6 @@ export class SilentEchoValidator {
             }
             if (totalSequences > currentSequenceIndex) {
                 await this.silentEcho.message("Alexa, exit");
-                if (process.env.ENABLE_MESSAGES_MOCK !== "true") {
-                    await new Promise((resolve) => setTimeout(resolve, 10000));
-                }
             }
         }
         const failures = result.tests.filter((test) => test.result === "failure");


### PR DESCRIPTION
#### Overview
- validator: removes 10s delay, we don't need it anymore, sending `quit` between sequences and at the beginning of the first sequence its fine for ending session.
- package: bumps version to the latest release

#### Test plan
- [x] Unit tests.
- [x] Manual tested via dashboard, and sending multiple sequences, it works as expected with/without 10s delay.