### PR TITLE
SilentEcho: adds normalizeMessage function

### DIFF
--- a/src/SilentEcho.ts
+++ b/src/SilentEcho.ts
@@ -8,7 +8,7 @@ export class SilentEcho {
     }
 
     public normalizeMessage(message: string): string {
-        if (message === "no") {
+        if (message.trim().toLowerCase() === "no") {
             return "alexa no";
         }
         return message;

--- a/src/SilentEcho.ts
+++ b/src/SilentEcho.ts
@@ -7,8 +7,19 @@ export class SilentEcho {
         this.baseURL = "https://silentecho.bespoken.io/process";
     }
 
+    public normalizeMessage(message: string): string {
+        if (message === "no") {
+            return "alexa no";
+        }
+        return message;
+
+    }
+
     public message(message: string, debug?: boolean): Promise<ISilentResult> {
+        message = this.normalizeMessage(message);
+
         let url = this.baseURL + "?message=" + message + "&user_id=" + this.token;
+
         if (debug) {
             url += "&debug=true";
         }

--- a/test/SilentEchoTest.ts
+++ b/test/SilentEchoTest.ts
@@ -58,7 +58,7 @@ describe("SilentEcho", function() {
     describe("#normalizeMessage()", () => {
         it("Should transform no to 'alexa no'", async () => {
             const sdk = new SilentEcho(process.env.TEST_TOKEN as string);
-            assert.equal(sdk.normalizeMessage("no"), "alexa no");
+            assert.equal(sdk.normalizeMessage("No"), "alexa no");
         });
     });
 });

--- a/test/SilentEchoTest.ts
+++ b/test/SilentEchoTest.ts
@@ -55,4 +55,10 @@ describe("SilentEcho", function() {
             assert.isDefined((result.debug as any).rawJSON.messageBody);
         });
     });
+    describe("#normalizeMessage()", () => {
+        it("Should transform no to 'alexa no'", async () => {
+            const sdk = new SilentEcho(process.env.TEST_TOKEN as string);
+            assert.equal(sdk.normalizeMessage("no"), "alexa no");
+        });
+    });
 });


### PR DESCRIPTION
#### Overview
- SilentEcho: adds `normalizeMessage` function, handles messages transformation:
  - `no` -> `alexa no`
- Closes: https://github.com/bespoken/silent-echo-sdk/issues/36

#### Test plan
- [x] Unit test.